### PR TITLE
fix build failure on x86

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   git_rev: v{{version}}
 
 build:
-  number: 0
+  number: 1
   string: py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed . -vv
 
@@ -23,6 +23,7 @@ requirements:
     - openssl
     - zlib             {{ zlib }}
     - pytorch-base     {{ pytorch }}
+    - pip
 
   run:
     - python


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Fixes the below error observed during build:
```
Error: No module named pip
[OPEN-CE-ERROR]-11 Unable to build recipe: torchdata-feedstock
[OPEN-CE-ERROR]-11 Unable to build recipe: torchdata-feedstock
```

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
